### PR TITLE
Add root redirect to login

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -5,6 +5,9 @@ const { check, validationResult } = require('express-validator');
 const bcrypt = require('bcryptjs');
 const { User } = require('../models');
 
+// Redirect root of auth router to the login page
+router.get('/', (req, res) => res.redirect('/login'));
+
 router.get('/login', (req, res) => {
   res.render('login');
 });


### PR DESCRIPTION
## Summary
- redirect root `/` path to login so unauthenticated visitors hit the login page

## Testing
- `npm install`
- `npm start` *(fails: ConnectionRefusedError - no running MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_685252fc5db8832db540e215a3f818be