### PR TITLE
Add root redirect to login

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -5,12 +5,20 @@ const { check, validationResult } = require('express-validator');
 const bcrypt = require('bcryptjs');
 const { User } = require('../models');
 
+// Redirect root of auth router to the login page
+router.get('/', (req, res) => res.redirect('/login'));
+
 router.get('/login', (req, res) => {
   res.render('login');
 });
 
+// Validate email with regex instead of built-in isEmail
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 router.post('/login', [
-  check('email').isEmail().withMessage('Correo inválido'),
+  check('email')
+    .matches(emailRegex)
+    .withMessage('Correo inválido'),
   check('password').notEmpty()
 ], async (req, res, next) => {
   const errors = validationResult(req);


### PR DESCRIPTION
## Summary
- redirect root `/` path to login so unauthenticated visitors hit the login page
- validate login email with regex before authenticating

## Testing
- `npm install`
- `npm start` *(fails: ConnectionRefusedError - no running MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_685252fc5db8832db540e215a3f818be