### PR TITLE
Fix table name mismatch in User model

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -11,6 +11,8 @@ const User = sequelize.define('User', {
     type: DataTypes.STRING,
     allowNull: false
   }
+}, {
+  tableName: 'usuarios'
 });
 
 module.exports = { User };


### PR DESCRIPTION
## Summary
- specify explicit table name `usuarios` in the Sequelize `User` model

## Testing
- `node -e "const {User} = require('./models'); console.log(User.getTableName());"`
- `npm start` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_6852caf2665c832db99024ad7f9e50cf